### PR TITLE
fix: eval reliability — rate-limit regex, split-aware sampling, stderr truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ python tools/setup.py --project-name my-agent --entry-point "python main.py" --f
 python tools/run_eval.py --config .evolver.json --worktree-path /tmp/wt --experiment-prefix v001a
 # Default concurrency is 3. Use --concurrency 1 for agents that can't run in parallel (shared files, fixed ports, etc)
 # Use --sample 10 to evaluate a random subset (used by light mode)
+# Use --sample 10 --sample-split train to sample from train only + always eval all held_out
 # Use --no-canary to skip preflight check
 
 # Compare experiment results

--- a/agents/harness-evaluator.md
+++ b/agents/harness-evaluator.md
@@ -165,7 +165,7 @@ langsmith-cli --json feedback list --run-id "{any_run_id}" --key correctness
 - If a run has `outputs` but they contain a non-429 error message: score `0.0` with comment explaining the failure
 - If `outputs` is empty but no error and no rate-limit: score `0.0` with comment "Empty output"
 
-To detect rate-limited runs, check if `outputs.error` or `outputs.output` contains "429", "RESOURCE_EXHAUSTED", "rate limit", or "quota exceeded".
+To detect rate-limited runs, check ONLY `outputs.error` (never `outputs.output`) for "429", "RESOURCE_EXHAUSTED", "rate limit", or "quota exceeded". Do NOT scan agent output text — words like "curated" or "temperature" cause false positives.
 
 ## Rules
 

--- a/skills/certify/SKILL.md
+++ b/skills/certify/SKILL.md
@@ -26,8 +26,7 @@ for i in 1 2 3; do
     $EVOLVER_PY $TOOLS/run_eval.py \
         --config .evolver.json \
         --worktree-path "." \
-        --experiment-prefix "certify-run-$i" \
-        --no-canary
+        --experiment-prefix "certify-run-$i"
 done
 ```
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -177,7 +177,7 @@ Run evaluations with mode parameters. `run_eval.py` auto-copies config files to 
 ```bash
 CONCURRENCY=$(python3 -c "m={'light':5,'balanced':3,'heavy':3}; print(m.get('$MODE',3))")
 TIMEOUT=$(python3 -c "m={'light':60,'balanced':120,'heavy':300}; print(m.get('$MODE',120))")
-SAMPLE=$(python3 -c "m={'light':'10','balanced':'','heavy':''}; s=m.get('$MODE',''); print(f'--sample {s}' if s else '')")
+SAMPLE=$(python3 -c "m={'light':'10','balanced':'','heavy':''}; s=m.get('$MODE',''); print(f'--sample {s} --sample-split train' if s else '')")
 
 for WT in {worktree_paths_with_commits}; do
     WT_PROJECT="$WT"

--- a/tools/_common.py
+++ b/tools/_common.py
@@ -10,7 +10,15 @@ Contains functions that were previously duplicated across multiple tool files:
 import json
 import os
 import platform
+import re
 import sys
+
+# Shared rate-limit detection regex — used by run_eval.py and read_results.py
+# Matches specific phrases (not bare "rate" which triggers on "curated", "hydrate", etc.)
+RATE_LIMIT_RE = re.compile(
+    r"\b429\b|rate[ _-]?limit|resource[_ ]exhausted|quota[_ ]?(exceeded|exhausted)",
+    re.IGNORECASE,
+)
 
 
 # Tracks where the API key was loaded from.

--- a/tools/read_results.py
+++ b/tools/read_results.py
@@ -510,6 +510,9 @@ def main():
             all_scores = [v["score"] for v in result["per_example"].values()]
             result["combined_score"] = sum(all_scores) / len(all_scores) if all_scores else 0.0
             result["num_examples"] = len(result["per_example"])
+            if all_scores and len(all_scores) < 5:
+                result["low_confidence"] = True
+                print(f"  WARNING: only {len(all_scores)} scored examples after '{args.split}' filter — score may be unreliable", file=sys.stderr)
 
         if args.format == "summary":
             output = json.dumps(format_summary(result), indent=2, default=str)
@@ -556,6 +559,9 @@ def main():
                         continue
                     result["combined_score"] = sum(all_scores) / len(all_scores)
                     result["num_examples"] = len(result["per_example"])
+                    if len(all_scores) < 5:
+                        result["low_confidence"] = True
+                        print(f"  WARNING: {name} has only {len(all_scores)} scored examples after '{args.split}' filter — comparison may be unreliable", file=sys.stderr)
                 results_list.append(result)
 
         if not results_list:

--- a/tools/read_results.py
+++ b/tools/read_results.py
@@ -25,12 +25,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _common import ensure_langsmith_api_key
-
-_RATE_LIMIT_RE = re.compile(
-    r"\b429\b|rate[ _-]?limit|resource[_ ]exhausted|quota[_ ]?(exceeded|exhausted)",
-    re.IGNORECASE,
-)
+from _common import ensure_langsmith_api_key, RATE_LIMIT_RE
 
 
 def weighted_score(scores, weights=None):
@@ -121,7 +116,7 @@ def read_experiment(client, experiment_name, weights=None):
         rate_limited_count = 0
         for eid, data in per_example.items():
             error_text = (data.get("error") or "")
-            is_rate_limited = bool(_RATE_LIMIT_RE.search(error_text))
+            is_rate_limited = bool(RATE_LIMIT_RE.search(error_text))
             if is_rate_limited:
                 rate_limited_count += 1
                 data["rate_limited"] = True

--- a/tools/read_results.py
+++ b/tools/read_results.py
@@ -21,10 +21,16 @@ Requires: pip install langsmith
 import argparse
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _common import ensure_langsmith_api_key
+
+_RATE_LIMIT_RE = re.compile(
+    r"\b429\b|rate[ _-]?limit|resource[_ ]exhausted|quota[_ ]?(exceeded|exhausted)",
+    re.IGNORECASE,
+)
 
 
 def weighted_score(scores, weights=None):
@@ -111,13 +117,11 @@ def read_experiment(client, experiment_name, weights=None):
         num_examples = len(per_example)
 
         # Exclude rate-limited runs from combined score (they're infra failures, not agent failures)
-        rate_limit_keywords = ("429", "rate", "resource_exhausted", "quota")
         scored_examples = {}
         rate_limited_count = 0
         for eid, data in per_example.items():
-            error_text = (data.get("error") or "").lower()
-            output_text = (data.get("output_preview") or "").lower()
-            is_rate_limited = any(kw in error_text or kw in output_text for kw in rate_limit_keywords)
+            error_text = (data.get("error") or "")
+            is_rate_limited = bool(_RATE_LIMIT_RE.search(error_text))
             if is_rate_limited:
                 rate_limited_count += 1
                 data["rate_limited"] = True

--- a/tools/run_eval.py
+++ b/tools/run_eval.py
@@ -162,6 +162,7 @@ def main():
     parser.add_argument("--retry-on-rate-limit", action="store_true",
                         help="If rate-limited, wait 60s and suggest re-run")
     parser.add_argument("--sample", type=int, default=None, help="Evaluate a random sample of N examples instead of all")
+    parser.add_argument("--sample-split", default=None, help="When --sample is used, sample from this split only (e.g., 'train'). Remaining splits are always fully evaluated.")
     args = parser.parse_args()
 
     # Auto-copy config files to worktree if missing (untracked files aren't in worktrees)
@@ -191,7 +192,16 @@ def main():
     if args.sample:
         import random
         all_examples = list(client.list_examples(dataset_name=config["dataset"], limit=500))
-        if args.sample < len(all_examples):
+
+        if args.sample_split:
+            # Split-aware sampling: sample N from the specified split, include ALL other splits
+            split_examples = list(client.list_examples(dataset_name=config["dataset"], splits=[args.sample_split]))
+            other_examples = [ex for ex in all_examples if ex.id not in {e.id for e in split_examples}]
+            n_sample = min(args.sample, len(split_examples))
+            sampled_from_split = random.sample(split_examples, n_sample) if n_sample < len(split_examples) else split_examples
+            sampled_examples = sampled_from_split + other_examples
+            print(f"  Sampling {n_sample}/{len(split_examples)} from '{args.sample_split}' + {len(other_examples)} from other splits = {len(sampled_examples)} total", file=sys.stderr)
+        elif args.sample < len(all_examples):
             sampled_examples = random.sample(all_examples, args.sample)
             print(f"  Sampling {args.sample}/{len(all_examples)} examples", file=sys.stderr)
         else:

--- a/tools/run_eval.py
+++ b/tools/run_eval.py
@@ -19,19 +19,13 @@ Requires: pip install langsmith
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _common import ensure_langsmith_api_key
-
-_RATE_LIMIT_RE = re.compile(
-    r"\b429\b|rate[ _-]?limit|resource[_ ]exhausted|quota[_ ]?(exceeded|exhausted)",
-    re.IGNORECASE,
-)
+from _common import ensure_langsmith_api_key, RATE_LIMIT_RE
 
 
 def make_target(entry_point, cwd):
@@ -164,6 +158,9 @@ def main():
     parser.add_argument("--sample", type=int, default=None, help="Evaluate a random sample of N examples instead of all")
     parser.add_argument("--sample-split", default=None, help="When --sample is used, sample from this split only (e.g., 'train'). Remaining splits are always fully evaluated.")
     args = parser.parse_args()
+
+    if args.sample_split and not args.sample:
+        print("  WARNING: --sample-split has no effect without --sample", file=sys.stderr)
 
     # Auto-copy config files to worktree if missing (untracked files aren't in worktrees)
     config_dir = os.path.dirname(os.path.abspath(args.config))
@@ -317,7 +314,7 @@ def main():
             # Detect rate-limit in this run's error (never check output — words like "curated" cause false positives)
             if outputs and isinstance(outputs, dict):
                 error_text = str(outputs.get("error", ""))
-                if _RATE_LIMIT_RE.search(error_text):
+                if RATE_LIMIT_RE.search(error_text):
                     rate_limit_count += 1
 
             # Early abort: after 5+ runs, if >50% are rate-limited, stop burning quota

--- a/tools/run_eval.py
+++ b/tools/run_eval.py
@@ -19,6 +19,7 @@ Requires: pip install langsmith
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,11 @@ import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _common import ensure_langsmith_api_key
+
+_RATE_LIMIT_RE = re.compile(
+    r"\b429\b|rate[ _-]?limit|resource[_ ]exhausted|quota[_ ]?(exceeded|exhausted)",
+    re.IGNORECASE,
+)
 
 
 def make_target(entry_point, cwd):
@@ -93,7 +99,10 @@ def make_target(entry_point, cwd):
 
             # Accept segfault (139) if output was produced
             if result.returncode != 0:
-                return {"output": "", "error": result.stderr.strip()[:500]}
+                stderr = result.stderr.strip()
+                # Capture tail of stderr (traceback/error is at the end, not the beginning)
+                error_msg = stderr[-500:] if len(stderr) > 500 else stderr
+                return {"output": "", "error": error_msg}
 
             return {"output": ""}
 
@@ -295,11 +304,10 @@ def main():
                 run_obj = getattr(result, "run", None)
                 outputs = getattr(run_obj, "outputs", {}) if run_obj else {}
 
-            # Detect rate-limit in this run's output
+            # Detect rate-limit in this run's error (never check output — words like "curated" cause false positives)
             if outputs and isinstance(outputs, dict):
-                error_text = str(outputs.get("error", "")).lower()
-                output_text = str(outputs.get("output", "")).lower()
-                if "429" in error_text or "rate" in error_text or "resource_exhausted" in error_text or "429" in output_text:
+                error_text = str(outputs.get("error", ""))
+                if _RATE_LIMIT_RE.search(error_text):
                     rate_limit_count += 1
 
             # Early abort: after 5+ runs, if >50% are rate-limited, stop burning quota


### PR DESCRIPTION
## Summary

Fixes 3 evaluation reliability bugs discovered during real-world testing on a CrewAI trip planner agent where `best_score: 1.0` was inflated from a true score of ~0.90.

- **Rate-limit false positives**: Bare `"rate"` substring matched "curated", "hydrate", "karate" in agent output, silently excluding valid results from scoring. Replaced with `RATE_LIMIT_RE` regex (shared in `_common.py`) that matches specific phrases. Now only checks error fields, never output text.
- **Split-aware sampling**: `--sample 10` sampled from all examples but comparison filtered to held_out — leaving only 2-3 scored examples. New `--sample-split train` flag samples from train only and always evaluates all held_out. Evolve skill passes this in light mode.
- **stderr tail truncation**: Changed `stderr[:500]` to `stderr[-500:]` so actual error tracebacks are captured instead of startup banners.
- **Certify canary**: Removed `--no-canary` from certify skill so broken agents are caught immediately.
- **Minimum N guard**: `read_results.py` emits `low_confidence: true` when comparison has fewer than 5 scored examples.

## Test Plan

- [x] All 19 tests pass
- [x] `--sample-split` visible in `--help`
- [x] Warning emitted when `--sample-split` used without `--sample`
- [x] `RATE_LIMIT_RE` shared from `_common.py` (no duplication)
- [ ] Run `/harness:evolve` on playground agent to verify end-to-end