### PR TITLE
feat: Autogenesis-inspired RSPL registry, contract extraction, archive retrieval, regime-aware lenses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,25 @@ python tools/add_evaluator.py --config .evolver.json --evaluator factual_accurac
 
 # Inject adversarial examples
 python tools/adversarial_inject.py --config .evolver.json --experiment v003a --inject
+
+# Extract a consolidated capability contract (AGP Contract Generation)
+# AST-walk the agent source tree and emit contracts.md (signatures + docstrings
+# + @tool decorators). Reduces prompt bloat and keeps prompts synced with code.
+python tools/extract_contracts.py --root . --output contracts.md
+python tools/extract_contracts.py --config .evolver.json --output contracts.md  # use entry_point
+
+# Build the RSPL-lite resource registry (AGP Layer 1)
+# Classifies project files into prompt/tool/agent/environment/memory, hashes and
+# versions them. Proposers can target a single type via the evolvable flag.
+python tools/resource_registry.py --root .
+python tools/resource_registry.py --root . --list --type tool
+python tools/resource_registry.py --root . --freeze prompts/system.md  # mark non-evolvable
+
+# TF-IDF retrieval over the evolution archive (AGP retrieve operator)
+# Returns top-k historically similar candidates for a lens/failure description.
+python tools/archive_search.py --config .evolver.json --query "retry rate limit"
+python tools/archive_search.py --config .evolver.json --query-file lenses.json --winners-only --top 3
+python tools/archive_search.py --config .evolver.json --query "..." --losers-only --format json
 ```
 
 ## Testing
@@ -115,7 +134,7 @@ Three layers, each in its own directory:
 
 2. **Agents** (`agents/*.md`) — Markdown agent definitions spawned by skills via `Agent()`. Six agent types: `harness-proposer` (green, self-organizing with lens protocol, runs in worktree with `acceptEdits`), `harness-evaluator` (yellow, LLM-as-judge via langsmith-cli), `harness-critic` (red, active — detects + fixes gaming), `harness-architect` (blue, ULTRAPLAN mode with opus), `harness-consolidator` (cyan, cross-iteration memory), `harness-testgen` (cyan). Each has a frontmatter block defining `name`, `tools`, `color`, and `permissionMode`.
 
-3. **Tools** (`tools/*.py`) — Python scripts that interface with LangSmith SDK. All tools share a common `ensure_langsmith_api_key()` pattern that loads the key from the credentials file if not in env. `analyze_architecture.py`, `evolution_chart.py`, `constraint_check.py`, `secret_filter.py`, `mine_sessions.py`, and `promote_learnings.py` are stdlib-only (no langsmith dependency). `validate_state.py`, `iteration_gate.py`, `regression_tracker.py`, `consolidate.py`, `synthesize_strategy.py`, `add_evaluator.py`, and `dataset_health.py` are new v4.0+ tools. `evolution_chart.py` renders a rich ASCII evolution chart with score progression, per-evaluator breakdown, change narrative, and bar chart. `dataset_health.py` checks dataset quality (size, difficulty distribution, coverage, splits) and outputs actionable corrections. `consolidate.py` and `synthesize_strategy.py` are stdlib-only (no langsmith dependency for core logic).
+3. **Tools** (`tools/*.py`) — Python scripts that interface with LangSmith SDK. All tools share a common `ensure_langsmith_api_key()` pattern that loads the key from the credentials file if not in env. `analyze_architecture.py`, `evolution_chart.py`, `constraint_check.py`, `secret_filter.py`, `mine_sessions.py`, `promote_learnings.py`, `extract_contracts.py`, `resource_registry.py`, and `archive_search.py` are stdlib-only (no langsmith dependency). `validate_state.py`, `iteration_gate.py`, `regression_tracker.py`, `consolidate.py`, `synthesize_strategy.py`, `add_evaluator.py`, and `dataset_health.py` are new v4.0+ tools. `evolution_chart.py` renders a rich ASCII evolution chart with score progression, per-evaluator breakdown, change narrative, and bar chart. `dataset_health.py` checks dataset quality (size, difficulty distribution, coverage, splits) and outputs actionable corrections. `consolidate.py` and `synthesize_strategy.py` are stdlib-only (no langsmith dependency for core logic).
 
 Supporting infrastructure:
 - **Plugin manifest** (`.claude-plugin/plugin.json`) — registers as a Claude Code plugin
@@ -129,15 +148,28 @@ Supporting infrastructure:
 `/harness:health` → checks dataset quality (size, difficulty, coverage, splits), auto-corrects issues
 
 `/harness:evolve` → reads `.evolver.json`, invokes `/harness:health`, then per iteration:
-1. `trace_insights.py` gathers failure data from best experiment
-2. Claude generates `strategy.md` + `lenses.json` directly from analysis data (no intermediate Python tool)
-3. Spawns N `harness-proposer` agents in parallel (each in `isolation: "worktree"`, `run_in_background: true`) with dynamic investigation lenses — each proposer self-organizes its approach and may self-abstain
-4. `run_eval.py` evaluates each candidate (code-based evaluators only)
-5. Spawns 1 `harness-evaluator` agent to score ALL candidates via langsmith-cli (LLM-as-judge)
-6. `read_results.py` compares experiments, picks winner + per-task champion
-7. Merges winning worktree branch into main, updates `.evolver.json`
-8. Claude assesses gate conditions (plateau, target, diminishing returns) — no intermediate Python tool
-9. Auto-triggers `harness-critic` if score jumped >0.3, `harness-architect` if stagnated
+1. **ρ Reflect** — `trace_insights.py` gathers failure data from best experiment
+2. **σ Select** — `synthesize_strategy.py` generates `strategy.md` + `lenses.json` (regime-aware: weak → prompt lens, ceiling → tool-gap lens)
+3. **ι Improve** — spawns N `harness-proposer` agents in parallel (each in `isolation: "worktree"`, `run_in_background: true`) with dynamic investigation lenses — each proposer self-organizes its approach and may self-abstain
+4. **ε Evaluate** — `run_eval.py` evaluates each candidate (code-based evaluators only) + 1 `harness-evaluator` agent scores ALL candidates via langsmith-cli (LLM-as-judge)
+5. `read_results.py` compares experiments, picks winner + per-task champion
+6. **κ Commit** — merges winning worktree branch into main, updates `.evolver.json`, `archive.py` saves candidate artifacts
+7. Claude assesses gate conditions (plateau, target, diminishing returns)
+8. Auto-triggers `harness-critic` if score jumped >0.3, `harness-architect` if stagnated
+
+The ρ/σ/ι/ε/κ labels follow the Autogenesis AGP operator algebra (Reflect, Select, Improve, Evaluate, Commit). The current instantiation uses reflection-driven optimization; TextGrad, GRPO, and Reinforce++ fit the same interface as future optimizer variants.
+
+## Resource model (RSPL-lite)
+
+`resource_registry.py` classifies every file in the user's project into one of five entity types, following Autogenesis RSPL Layer 1:
+
+- **prompt** — `.md`/`.txt`/`.prompt` templates with second-person or `{placeholder}` markers
+- **tool** — Python modules with `@tool`/`@function_tool`/`@skill` decorators or under `tools/`
+- **agent** — Python modules referencing `StateGraph`, `ReActAgent`, `AgentExecutor`, etc.
+- **environment** — `.yaml`/`.toml`/`.ini`/`.env` config files (secrets auto-frozen)
+- **memory** — files under `memory/`, `knowledge/`, or named `evolution_memory.*`
+
+Each resource gets a content hash, auto-incrementing version on change, and an `evolvable` flag (the binary learnability mask from the paper). `.env` and files matching `credentials|secret|token` are always frozen. Deleted resources are retained as tombstones with `removed_at` for audit. The registry lives at `.evolver/resources.json`.
 
 ## Dev skills (`.claude/`)
 

--- a/tools/archive_search.py
+++ b/tools/archive_search.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""TF-IDF retrieval over the evolution archive.
+
+Reads every evolution_archive/{version}/ directory next to `.evolver.json`,
+builds a bag-of-words index over each candidate's proposal + diff + metadata,
+and returns the top-k historically most similar candidates for a given query.
+
+This gives proposers a "retrieval substrate" so that when a lens lands on a
+failure cluster that's already been attacked before, the proposer sees which
+prior approaches worked (and which didn't) rather than re-discovering them
+from scratch. Maps to Autogenesis `retrieve` operator over the registry.
+
+Stdlib-only. No external dependencies, no LLM calls.
+
+Usage:
+    # Search for prior attempts related to "retry on rate limit"
+    python3 archive_search.py --config .evolver.json --query "retry on rate limit errors"
+
+    # Pull only past winners (approaches that scored higher than baseline)
+    python3 archive_search.py --config .evolver.json --query "..." --winners-only
+
+    # Pull only past losers (useful to avoid re-trying them)
+    python3 archive_search.py --config .evolver.json --query "..." --losers-only --top 5
+
+    # Use a lens file as the query
+    python3 archive_search.py --config .evolver.json --query-file lenses.json --top 3
+"""
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from collections import Counter
+
+
+STOPWORDS = frozenset("""
+a an the and or but of for to in on at by with from into onto over under is are was were be been being
+have has had do does did will would could should may might must can do doesn't don't it its that this these
+those as if then than so such not no yes which what when where why how who whom whose
+also just only very much more most less least some any all each every both neither either
+about above across after against along around before behind below beside between beyond during except inside
+i you he she we they me him her us them my your our their his hers theirs
+""".split())
+
+TOKEN_RE = re.compile(r"[a-z_][a-z0-9_]{2,}")
+
+
+def load_json_safe(path):
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def tokenize(text):
+    """Lowercase + word-split; drop stopwords and super short tokens."""
+    if not text:
+        return []
+    return [t for t in TOKEN_RE.findall(text.lower()) if t not in STOPWORDS]
+
+
+def read_candidate(dir_path):
+    """Read one archive/{version}/ directory, return a candidate dict or None."""
+    meta = load_json_safe(os.path.join(dir_path, "meta.json"))
+    if not meta:
+        return None
+    chunks = []
+    chunks.append(meta.get("approach", "") or "")
+    chunks.append(meta.get("lens", "") or "")
+    for name in ("proposal.md", "diff_stat.txt", "diff.patch"):
+        p = os.path.join(dir_path, name)
+        if os.path.exists(p):
+            try:
+                with open(p, encoding="utf-8", errors="replace") as f:
+                    chunks.append(f.read())
+            except OSError:
+                pass
+    text = "\n".join(chunks)
+    return {
+        "version": os.path.basename(dir_path),
+        "meta": meta,
+        "tokens": tokenize(text),
+        "text": text,
+    }
+
+
+def build_index(archive_root):
+    """Build corpus + IDF across all candidates."""
+    candidates = []
+    if not os.path.isdir(archive_root):
+        return candidates, {}
+    for name in sorted(os.listdir(archive_root)):
+        dpath = os.path.join(archive_root, name)
+        if not os.path.isdir(dpath):
+            continue
+        cand = read_candidate(dpath)
+        if cand and cand["tokens"]:
+            candidates.append(cand)
+
+    # Document frequencies
+    df = Counter()
+    for c in candidates:
+        for term in set(c["tokens"]):
+            df[term] += 1
+
+    n = len(candidates) or 1
+    idf = {term: math.log((1 + n) / (1 + f)) + 1.0 for term, f in df.items()}
+    # Precompute per-candidate weighted vector + norm
+    for c in candidates:
+        tf = Counter(c["tokens"])
+        vec = {t: (1 + math.log(cnt)) * idf.get(t, 0.0) for t, cnt in tf.items()}
+        norm = math.sqrt(sum(w * w for w in vec.values())) or 1.0
+        c["vec"] = vec
+        c["norm"] = norm
+
+    return candidates, idf
+
+
+def score_query(query_text, candidates, idf):
+    """Cosine similarity between query and each candidate."""
+    qtokens = tokenize(query_text)
+    if not qtokens:
+        return []
+    tf = Counter(qtokens)
+    qvec = {t: (1 + math.log(cnt)) * idf.get(t, 0.0) for t, cnt in tf.items() if idf.get(t, 0.0) > 0}
+    qnorm = math.sqrt(sum(w * w for w in qvec.values())) or 1.0
+
+    results = []
+    for c in candidates:
+        cvec = c["vec"]
+        # Iterate the smaller dict for speed
+        if len(qvec) < len(cvec):
+            dot = sum(w * cvec.get(t, 0.0) for t, w in qvec.items())
+        else:
+            dot = sum(w * qvec.get(t, 0.0) for t, w in cvec.items())
+        sim = dot / (qnorm * c["norm"])
+        if sim > 0:
+            results.append((sim, c))
+    results.sort(key=lambda x: x[0], reverse=True)
+    return results
+
+
+def snippet_from(text, qtokens, radius=120, max_len=300):
+    """Pick a small window around the first query-token hit."""
+    if not text:
+        return ""
+    lower = text.lower()
+    best = -1
+    for tok in qtokens:
+        i = lower.find(tok)
+        if i >= 0 and (best < 0 or i < best):
+            best = i
+    if best < 0:
+        return text[:max_len].strip()
+    start = max(0, best - radius)
+    end = min(len(text), best + radius)
+    slice_ = text[start:end].strip()
+    if len(slice_) > max_len:
+        slice_ = slice_[:max_len]
+    return ("…" if start > 0 else "") + slice_ + ("…" if end < len(text) else "")
+
+
+def _is_winner(meta):
+    """A candidate is a winner if meta.won is true or score exceeds any recorded baseline."""
+    if meta.get("won") is True:
+        return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="TF-IDF retrieval over the evolution archive.")
+    parser.add_argument("--config", default=".evolver.json")
+    parser.add_argument("--archive", default=None,
+                        help="Archive root (default: {config_dir}/evolution_archive)")
+    parser.add_argument("--query", default=None, help="Free-text query")
+    parser.add_argument("--query-file", default=None,
+                        help="Read query from file (txt/md/json). For JSON, all string values are concatenated.")
+    parser.add_argument("--top", type=int, default=3, help="Return top-k results (default 3)")
+    parser.add_argument("--winners-only", action="store_true")
+    parser.add_argument("--losers-only", action="store_true")
+    parser.add_argument("--min-similarity", type=float, default=0.05)
+    parser.add_argument("--format", choices=["text", "json", "markdown"], default="markdown")
+    args = parser.parse_args()
+
+    if args.winners_only and args.losers_only:
+        print("Cannot combine --winners-only and --losers-only", file=sys.stderr)
+        sys.exit(2)
+
+    # Resolve archive root
+    if args.archive:
+        archive_root = os.path.abspath(args.archive)
+    else:
+        config_dir = os.path.dirname(os.path.abspath(args.config))
+        archive_root = os.path.join(config_dir, "evolution_archive")
+
+    # Resolve query
+    query_text = args.query or ""
+    if args.query_file:
+        try:
+            with open(args.query_file) as f:
+                raw = f.read()
+        except OSError as e:
+            print(f"Cannot read --query-file: {e}", file=sys.stderr)
+            sys.exit(1)
+        if args.query_file.endswith(".json"):
+            try:
+                obj = json.loads(raw)
+                # Flatten all string values
+                buf = []
+                def walk(v):
+                    if isinstance(v, str):
+                        buf.append(v)
+                    elif isinstance(v, dict):
+                        for vv in v.values():
+                            walk(vv)
+                    elif isinstance(v, list):
+                        for vv in v:
+                            walk(vv)
+                walk(obj)
+                raw = "\n".join(buf)
+            except json.JSONDecodeError:
+                pass
+        query_text = (query_text + "\n" + raw).strip()
+
+    if not query_text:
+        print("Need --query or --query-file", file=sys.stderr)
+        sys.exit(2)
+
+    candidates, idf = build_index(archive_root)
+    if not candidates:
+        print(json.dumps({"archive": archive_root, "results": [], "note": "archive empty"}, indent=2))
+        return
+
+    scored = score_query(query_text, candidates, idf)
+    if args.winners_only:
+        scored = [(s, c) for s, c in scored if _is_winner(c["meta"])]
+    if args.losers_only:
+        scored = [(s, c) for s, c in scored if not _is_winner(c["meta"])]
+    scored = [x for x in scored if x[0] >= args.min_similarity][: args.top]
+
+    qtokens = tokenize(query_text)
+
+    if args.format == "json":
+        out = {
+            "query": query_text[:500],
+            "archive": archive_root,
+            "total_candidates": len(candidates),
+            "results": [
+                {
+                    "version": c["version"],
+                    "similarity": round(sim, 4),
+                    "score": c["meta"].get("score"),
+                    "won": bool(c["meta"].get("won")),
+                    "approach": c["meta"].get("approach"),
+                    "lens": c["meta"].get("lens"),
+                    "snippet": snippet_from(c["text"], qtokens),
+                }
+                for sim, c in scored
+            ],
+        }
+        print(json.dumps(out, indent=2))
+        return
+
+    if args.format == "text":
+        for sim, c in scored:
+            meta = c["meta"]
+            flag = "WIN" if _is_winner(meta) else "loss"
+            print(f"{sim:.3f}  [{flag}]  {c['version']}  score={meta.get('score')}  "
+                  f"lens={meta.get('lens','')[:60]}  approach={meta.get('approach','')[:60]}")
+        return
+
+    # markdown (default)
+    print(f"# Archive search results  ({len(scored)}/{len(candidates)} candidates)")
+    print()
+    print(f"**Query:** `{query_text[:200]}`")
+    print()
+    for sim, c in scored:
+        meta = c["meta"]
+        flag = "winner" if _is_winner(meta) else "loser"
+        print(f"## {c['version']}  — similarity {sim:.3f}  ({flag})")
+        if meta.get("score") is not None:
+            print(f"- **score**: {meta['score']}")
+        if meta.get("lens"):
+            print(f"- **lens**: {meta['lens']}")
+        if meta.get("approach"):
+            print(f"- **approach**: {meta['approach']}")
+        snip = snippet_from(c["text"], qtokens)
+        if snip:
+            print()
+            print("```")
+            print(snip)
+            print("```")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extract_contracts.py
+++ b/tools/extract_contracts.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Extract a consolidated contract document from agent source code.
+
+Walks Python source files in a project and produces a single contracts.md
+listing every tool, function, and class with its signature, docstring, and
+decorator hints. The intent (from Autogenesis AGP, Layer 1) is to give the
+proposer a stable, up-to-date description of the agent's capability surface
+without re-reading every source file — reducing prompt bloat and eliminating
+prompt/code drift.
+
+Outputs:
+    contracts.md   — human/LLM-readable capability document
+    contracts.json — machine-readable index of the same data
+
+Stdlib-only. No external dependencies.
+
+Usage:
+    # Scan current directory
+    python3 extract_contracts.py --root . --output contracts.md
+
+    # Scan a worktree before a proposer run
+    python3 extract_contracts.py --root /tmp/wt --output /tmp/wt/contracts.md
+
+    # Limit scan to entry-point files listed in .evolver.json
+    python3 extract_contracts.py --config .evolver.json --output contracts.md
+"""
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+
+
+# Decorators that typically mark a function as a callable tool/skill.
+# Matched by the final attribute name, so `langchain_core.tools.tool`
+# and a bare `tool` both match.
+TOOL_DECORATORS = {
+    "tool",
+    "function_tool",
+    "openai_function",
+    "openai_tool",
+    "anthropic_tool",
+    "agent_tool",
+    "register_tool",
+    "skill",
+}
+
+EXCLUDE_DIR_NAMES = {
+    "__pycache__",
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".worktrees",
+    "evolution_archive",
+    ".evolver",
+    "dist",
+    "build",
+}
+
+
+def _decorator_name(dec):
+    """Best-effort name for a decorator AST node."""
+    if isinstance(dec, ast.Name):
+        return dec.id
+    if isinstance(dec, ast.Attribute):
+        return dec.attr
+    if isinstance(dec, ast.Call):
+        return _decorator_name(dec.func)
+    return None
+
+
+def _format_arg(arg, default=None):
+    """Render a function argument as source-like text."""
+    text = arg.arg
+    if arg.annotation is not None:
+        try:
+            text += ": " + ast.unparse(arg.annotation)
+        except Exception:
+            pass
+    if default is not None:
+        try:
+            text += " = " + ast.unparse(default)
+        except Exception:
+            pass
+    return text
+
+
+def _format_signature(fn):
+    """Render a function/async-function signature as `name(args) -> ret`."""
+    args = fn.args
+    positional = list(args.posonlyargs) + list(args.args)
+    defaults = list(args.defaults)
+    # Align defaults to the tail of positional args.
+    pad = len(positional) - len(defaults)
+    default_map = [None] * pad + defaults
+
+    rendered = [_format_arg(a, d) for a, d in zip(positional, default_map)]
+    if args.vararg is not None:
+        rendered.append("*" + _format_arg(args.vararg))
+    elif args.kwonlyargs:
+        rendered.append("*")
+    for a, d in zip(args.kwonlyargs, args.kw_defaults):
+        rendered.append(_format_arg(a, d))
+    if args.kwarg is not None:
+        rendered.append("**" + _format_arg(args.kwarg))
+
+    sig = f"{fn.name}({', '.join(rendered)})"
+    if fn.returns is not None:
+        try:
+            sig += " -> " + ast.unparse(fn.returns)
+        except Exception:
+            pass
+    return sig
+
+
+def _first_docstring_line(doc):
+    if not doc:
+        return ""
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _extract_usage_examples(doc, max_examples=2):
+    """Pull fenced code blocks or Example: blocks from a docstring."""
+    if not doc:
+        return []
+    examples = []
+    # Fenced blocks
+    for match in re.finditer(r"```(?:python)?\n(.*?)```", doc, re.DOTALL):
+        snippet = match.group(1).strip()
+        if snippet:
+            examples.append(snippet)
+        if len(examples) >= max_examples:
+            return examples
+    # 'Example:' prose blocks
+    if "Example:" in doc or "Examples:" in doc:
+        parts = re.split(r"Examples?:", doc, maxsplit=1)
+        if len(parts) == 2:
+            tail = parts[1].strip()
+            snippet = "\n".join(line for line in tail.splitlines()[:6] if line.strip())
+            if snippet and snippet not in examples:
+                examples.append(snippet)
+    return examples[:max_examples]
+
+
+def extract_file_contracts(path, root):
+    """Parse a single Python file; return a dict of its contracts."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return None
+
+    rel_path = os.path.relpath(path, root)
+    module_doc = ast.get_docstring(tree) or ""
+
+    tools = []
+    functions = []
+    classes = []
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            dec_names = [_decorator_name(d) for d in node.decorator_list]
+            dec_names = [d for d in dec_names if d]
+            is_tool = any(d in TOOL_DECORATORS for d in dec_names)
+            entry = {
+                "name": node.name,
+                "signature": _format_signature(node),
+                "decorators": dec_names,
+                "doc": ast.get_docstring(node) or "",
+                "lineno": node.lineno,
+                "is_async": isinstance(node, ast.AsyncFunctionDef),
+                "examples": _extract_usage_examples(ast.get_docstring(node) or ""),
+            }
+            if is_tool:
+                tools.append(entry)
+            elif not node.name.startswith("_"):
+                functions.append(entry)
+        elif isinstance(node, ast.ClassDef):
+            methods = []
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if item.name.startswith("_") and item.name not in ("__init__", "__call__"):
+                        continue
+                    methods.append({
+                        "name": item.name,
+                        "signature": _format_signature(item),
+                        "doc": _first_docstring_line(ast.get_docstring(item) or ""),
+                    })
+            classes.append({
+                "name": node.name,
+                "doc": ast.get_docstring(node) or "",
+                "lineno": node.lineno,
+                "methods": methods,
+            })
+
+    return {
+        "path": rel_path,
+        "module_doc": module_doc,
+        "tools": tools,
+        "functions": functions,
+        "classes": classes,
+    }
+
+
+def walk_project(root):
+    """Yield absolute paths of Python files under root, skipping junk dirs."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIR_NAMES and not d.startswith(".")]
+        for name in filenames:
+            if name.endswith(".py") and not name.startswith("."):
+                yield os.path.join(dirpath, name)
+
+
+def resolve_roots(args):
+    """Resolve which files/directories to scan."""
+    if args.root:
+        return [os.path.abspath(args.root)]
+    if args.files:
+        return [os.path.abspath(p) for p in args.files]
+    if args.config:
+        try:
+            with open(args.config) as f:
+                cfg = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return [os.getcwd()]
+        entry = cfg.get("entry_point", "")
+        out = []
+        for token in entry.split():
+            if token.endswith(".py") and not token.startswith("-"):
+                out.append(os.path.abspath(token))
+        if out:
+            return out
+    return [os.getcwd()]
+
+
+def format_markdown(contracts):
+    """Render the contracts list as markdown."""
+    lines = [
+        "# Agent Contracts",
+        "",
+        "*Auto-generated capability surface. Do not edit by hand — run `extract_contracts.py`.*",
+        "",
+        f"*Files scanned: {len(contracts)}*",
+        "",
+    ]
+
+    all_tools = []
+    for c in contracts:
+        for t in c["tools"]:
+            all_tools.append((c["path"], t))
+    if all_tools:
+        lines.append("## Tools")
+        lines.append("")
+        for path, t in all_tools:
+            decs = ", ".join("@" + d for d in t["decorators"]) if t["decorators"] else ""
+            lines.append(f"### `{t['name']}`  — `{path}:{t['lineno']}` {decs}".rstrip())
+            lines.append("")
+            lines.append(f"```python\n{t['signature']}\n```")
+            if t["doc"]:
+                lines.append("")
+                lines.append(t["doc"].strip())
+            if t["examples"]:
+                lines.append("")
+                lines.append("**Example:**")
+                lines.append("")
+                lines.append(f"```python\n{t['examples'][0]}\n```")
+            lines.append("")
+
+    any_fn = any(c["functions"] for c in contracts)
+    if any_fn:
+        lines.append("## Public Functions")
+        lines.append("")
+        for c in contracts:
+            if not c["functions"]:
+                continue
+            lines.append(f"### `{c['path']}`")
+            lines.append("")
+            for fn in c["functions"]:
+                doc = _first_docstring_line(fn["doc"])
+                lines.append(f"- `{fn['signature']}` — {doc}" if doc else f"- `{fn['signature']}`")
+            lines.append("")
+
+    any_cls = any(c["classes"] for c in contracts)
+    if any_cls:
+        lines.append("## Classes")
+        lines.append("")
+        for c in contracts:
+            if not c["classes"]:
+                continue
+            lines.append(f"### `{c['path']}`")
+            lines.append("")
+            for cls in c["classes"]:
+                doc = _first_docstring_line(cls["doc"])
+                header = f"**`{cls['name']}`**" + (f" — {doc}" if doc else "")
+                lines.append(header)
+                for m in cls["methods"]:
+                    mdoc = f" — {m['doc']}" if m["doc"] else ""
+                    lines.append(f"  - `{m['signature']}`{mdoc}")
+                lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract capability contracts from agent source.")
+    parser.add_argument("--root", help="Project root to scan (default: derive from --config or CWD)")
+    parser.add_argument("--files", nargs="*", help="Explicit file list to scan")
+    parser.add_argument("--config", default=None, help="Use entry_point from .evolver.json to pick files")
+    parser.add_argument("--output", default="contracts.md", help="Markdown output path")
+    parser.add_argument("--json", default=None, help="Optional JSON index output")
+    args = parser.parse_args()
+
+    roots = resolve_roots(args)
+    files = []
+    scan_root = roots[0] if len(roots) == 1 and os.path.isdir(roots[0]) else os.getcwd()
+    for r in roots:
+        if os.path.isdir(r):
+            scan_root = r
+            files.extend(walk_project(r))
+        elif os.path.isfile(r):
+            files.append(r)
+
+    contracts = []
+    for path in sorted(set(files)):
+        entry = extract_file_contracts(path, scan_root)
+        if not entry:
+            continue
+        if not (entry["tools"] or entry["functions"] or entry["classes"]):
+            continue
+        contracts.append(entry)
+
+    md = format_markdown(contracts)
+    with open(args.output, "w") as f:
+        f.write(md)
+
+    json_path = args.json or (args.output[:-3] + ".json" if args.output.endswith(".md") else args.output + ".json")
+    with open(json_path, "w") as f:
+        json.dump({"files": contracts}, f, indent=2)
+
+    tool_count = sum(len(c["tools"]) for c in contracts)
+    fn_count = sum(len(c["functions"]) for c in contracts)
+    cls_count = sum(len(c["classes"]) for c in contracts)
+    print(f"Contracts: {tool_count} tools, {fn_count} functions, {cls_count} classes across {len(contracts)} files")
+    print(f"Wrote {args.output} and {json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/resource_registry.py
+++ b/tools/resource_registry.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""RSPL-lite resource registry for the agent project.
+
+Maps the Autogenesis Resource Substrate Protocol Layer (Layer 1) onto the
+user's project: scans the tree, classifies files into one of the five RSPL
+entity types (prompt, agent, tool, environment, memory), attaches a content
+hash + version, and marks which resources are evolvable. The output gives
+proposers a typed view of the evolvable surface so they can target
+"mutate only tools" or "mutate only prompts" instead of blindly editing
+arbitrary files.
+
+Versioning is incremental: on each scan, files whose hash changed relative
+to the previous registry receive version += 1; new files start at 1;
+deleted files are retained with a `removed_at` timestamp for audit.
+
+Output (by default, `.evolver/resources.json`):
+    {
+      "generated_at": "...",
+      "root": "...",
+      "counts": {"prompt": 3, "tool": 5, ...},
+      "resources": [
+        {"id": "tool/search.py", "type": "tool", "path": "tools/search.py",
+         "hash": "sha256:...", "version": 2, "evolvable": true, "size": 1234,
+         "reasons": ["@tool decorator"]},
+         ...
+      ]
+    }
+
+Stdlib-only. No external dependencies.
+
+Usage:
+    # Initial scan of the current project
+    python3 resource_registry.py --root . --output .evolver/resources.json
+
+    # Rescan (versions auto-bump on hash change)
+    python3 resource_registry.py --root . --output .evolver/resources.json
+
+    # Filter listing
+    python3 resource_registry.py --root . --list --type tool
+
+    # Mark a specific file non-evolvable
+    python3 resource_registry.py --root . --freeze tools/credentials.py
+"""
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+
+EXCLUDE_DIR_NAMES = {
+    "__pycache__",
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".worktrees",
+    ".claude",
+    "evolution_archive",
+    "dist",
+    "build",
+    "__pypackages__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".ipynb_checkpoints",
+}
+
+EXCLUDE_DIR_PREFIXES = (".",)  # hidden dirs except those listed explicitly below
+EXCLUDE_DIR_EXCEPTIONS = {".evolver"}  # still excluded but we will allow memory files inside
+
+
+PROMPT_PATH_HINTS = re.compile(r"(^|/)(prompts?|system_prompts?|templates?)(/|$)", re.IGNORECASE)
+PROMPT_FILENAME_HINTS = re.compile(r"(prompt|template|instruction)s?\.(md|txt|prompt|jinja2?)$", re.IGNORECASE)
+
+AGENT_PATH_HINTS = re.compile(r"(^|/)(agents?|graph|orchestrat(or|ion)|planner)(/|$)", re.IGNORECASE)
+AGENT_FILENAME_HINTS = re.compile(r"(agent|graph|planner|orchestrator|react|chain)\.py$", re.IGNORECASE)
+
+TOOL_PATH_HINTS = re.compile(r"(^|/)(tools?|skills?|functions?)(/|$)", re.IGNORECASE)
+
+MEMORY_PATH_HINTS = re.compile(r"(^|/)(memory|knowledge|context_store|persistent|state_store)(/|$)", re.IGNORECASE)
+MEMORY_FILENAME_HINTS = re.compile(r"(memory|knowledge|history|state_store)\..+$", re.IGNORECASE)
+
+ENV_EXTS = {".yaml", ".yml", ".toml", ".ini", ".cfg", ".env", ".conf"}
+ENV_FILENAMES = {".env", ".env.example", "config.yaml", "config.yml", "settings.yaml", "settings.yml"}
+
+# Files that should never be auto-mutated even if found.
+FROZEN_FILENAME_HINTS = re.compile(
+    r"(credentials?|secret|apikey|api_key|token|\.env$|\.env\.)",
+    re.IGNORECASE,
+)
+
+TOOL_DECORATORS = {
+    "tool", "function_tool", "openai_function", "openai_tool", "anthropic_tool",
+    "agent_tool", "register_tool", "skill",
+}
+
+AGENT_CLASS_HINTS = {
+    "StateGraph", "ChatCompletionAgent", "ReActAgent", "Agent", "Runnable",
+    "ChatAgent", "AgentExecutor", "LLMAgent",
+}
+
+
+def file_sha256(path):
+    """Return sha256 hex of file content, or None on read error."""
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def _py_has_tool_decorator(path):
+    """True if the Python file defines any @tool-decorated function."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=path)
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for d in node.decorator_list:
+                name = None
+                if isinstance(d, ast.Name):
+                    name = d.id
+                elif isinstance(d, ast.Attribute):
+                    name = d.attr
+                elif isinstance(d, ast.Call):
+                    inner = d.func
+                    name = inner.id if isinstance(inner, ast.Name) else getattr(inner, "attr", None)
+                if name in TOOL_DECORATORS:
+                    return True
+    return False
+
+
+def _py_looks_like_agent(path):
+    """True if the Python file references known agent framework classes/functions."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+    except (OSError, UnicodeDecodeError):
+        return False
+    for hint in AGENT_CLASS_HINTS:
+        if re.search(rf"\b{re.escape(hint)}\b", source):
+            return True
+    if re.search(r"\b(create_react_agent|StateGraph\().*", source):
+        return True
+    return False
+
+
+def _md_looks_like_prompt(path, rel_path):
+    """True if a markdown/text file looks like a prompt template."""
+    if PROMPT_PATH_HINTS.search(rel_path) or PROMPT_FILENAME_HINTS.search(rel_path):
+        return True
+    try:
+        with open(path, encoding="utf-8") as f:
+            head = f.read(2048)
+    except (OSError, UnicodeDecodeError):
+        return False
+    # Rough heuristic: prompt-like files usually use second person / template vars.
+    markers = ["You are ", "You must", "System:", "{input}", "{question}", "{context}"]
+    return any(m in head for m in markers)
+
+
+def classify(path, rel_path):
+    """Return (type, evolvable, reasons) for a file — or (None, _, _) to skip."""
+    reasons = []
+    basename = os.path.basename(path)
+    ext = os.path.splitext(basename)[1].lower()
+
+    # Frozen detection up front so it overrides type choice below.
+    frozen = bool(FROZEN_FILENAME_HINTS.search(rel_path))
+
+    # Memory
+    if MEMORY_PATH_HINTS.search(rel_path) or MEMORY_FILENAME_HINTS.match(basename):
+        reasons.append("memory path/filename")
+        return "memory", not frozen, reasons
+
+    # Environment / config
+    if basename in ENV_FILENAMES or ext in ENV_EXTS:
+        reasons.append(f"config file ({ext or basename})")
+        # .env-style secrets are not evolvable
+        return "environment", not frozen, reasons
+
+    # Prompt (markdown/text)
+    if ext in {".md", ".txt", ".prompt", ".jinja", ".jinja2"} and _md_looks_like_prompt(path, rel_path):
+        reasons.append("prompt template")
+        return "prompt", not frozen, reasons
+
+    # Python — decide between tool and agent
+    if ext == ".py":
+        if _py_has_tool_decorator(path):
+            reasons.append("@tool decorator")
+            return "tool", not frozen, reasons
+        if TOOL_PATH_HINTS.search(rel_path):
+            reasons.append("tools/ path")
+            return "tool", not frozen, reasons
+        if _py_looks_like_agent(path) or AGENT_PATH_HINTS.search(rel_path) or AGENT_FILENAME_HINTS.search(basename):
+            reasons.append("agent framework class/function")
+            return "agent", not frozen, reasons
+        # Generic Python — only register if we can see it's meaningful
+        return None, False, reasons
+
+    return None, False, reasons
+
+
+def walk_project(root):
+    for dirpath, dirnames, filenames in os.walk(root):
+        pruned = []
+        for d in dirnames:
+            if d in EXCLUDE_DIR_NAMES:
+                continue
+            if d.startswith(EXCLUDE_DIR_PREFIXES) and d not in EXCLUDE_DIR_EXCEPTIONS:
+                continue
+            pruned.append(d)
+        dirnames[:] = pruned
+        for name in filenames:
+            if name.startswith(".") and name not in ENV_FILENAMES:
+                continue
+            yield os.path.join(dirpath, name)
+
+
+def resource_id(rtype, rel_path):
+    """Stable id based on type and normalized relative path."""
+    normalized = rel_path.replace(os.sep, "/")
+    return f"{rtype}/{normalized}"
+
+
+def load_existing(path):
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def build_registry(root, previous=None, freeze_paths=None):
+    freeze_set = {os.path.normpath(p) for p in (freeze_paths or [])}
+    prev_map = {}
+    if previous:
+        for r in previous.get("resources", []):
+            prev_map[r["id"]] = r
+
+    seen_ids = set()
+    resources = []
+    for abspath in walk_project(root):
+        rel = os.path.relpath(abspath, root)
+        rtype, evolvable, reasons = classify(abspath, rel)
+        if not rtype:
+            continue
+        rid = resource_id(rtype, rel)
+        seen_ids.add(rid)
+        h = file_sha256(abspath)
+        if h is None:
+            continue
+        size = os.path.getsize(abspath)
+        prev = prev_map.get(rid)
+        if prev and prev.get("hash") == "sha256:" + h:
+            version = prev.get("version", 1)
+        elif prev:
+            version = prev.get("version", 1) + 1
+        else:
+            version = 1
+        if os.path.normpath(rel) in freeze_set:
+            evolvable = False
+            reasons.append("frozen by --freeze")
+        resources.append({
+            "id": rid,
+            "type": rtype,
+            "path": rel.replace(os.sep, "/"),
+            "hash": "sha256:" + h,
+            "version": version,
+            "evolvable": evolvable,
+            "size": size,
+            "reasons": reasons,
+            "last_modified": datetime.fromtimestamp(os.path.getmtime(abspath), tz=timezone.utc).isoformat(),
+        })
+
+    # Carry forward tombstones for deleted resources.
+    removed = []
+    for rid, prev in prev_map.items():
+        if rid not in seen_ids and not prev.get("removed_at"):
+            tomb = dict(prev)
+            tomb["removed_at"] = datetime.now(timezone.utc).isoformat()
+            removed.append(tomb)
+
+    counts = {}
+    for r in resources:
+        counts[r["type"]] = counts.get(r["type"], 0) + 1
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "root": os.path.abspath(root),
+        "counts": counts,
+        "resources": resources,
+        "removed": removed,
+    }
+
+
+def format_summary(registry):
+    counts = registry.get("counts", {})
+    lines = [
+        f"Registry: {len(registry['resources'])} active resources  "
+        + ", ".join(f"{k}:{v}" for k, v in sorted(counts.items())),
+    ]
+    if registry.get("removed"):
+        lines.append(f"Tombstones: {len(registry['removed'])}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build an RSPL-lite resource registry for the project.")
+    parser.add_argument("--root", default=".", help="Project root (default: CWD)")
+    parser.add_argument("--output", default=None,
+                        help="Registry output path (default: {root}/.evolver/resources.json)")
+    parser.add_argument("--list", action="store_true", help="Print the registry to stdout instead of writing it")
+    parser.add_argument("--type", choices=["prompt", "tool", "agent", "environment", "memory"],
+                        help="Filter listing by type")
+    parser.add_argument("--evolvable-only", action="store_true", help="Filter to evolvable resources")
+    parser.add_argument("--freeze", action="append", default=[],
+                        help="Mark a path as non-evolvable (repeatable)")
+    args = parser.parse_args()
+
+    root = os.path.abspath(args.root)
+    if not os.path.isdir(root):
+        print(f"Not a directory: {root}", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = args.output or os.path.join(root, ".evolver", "resources.json")
+    args.output = output_path
+    previous = load_existing(output_path)
+    registry = build_registry(root, previous=previous, freeze_paths=args.freeze)
+
+    if args.list:
+        rows = registry["resources"]
+        if args.type:
+            rows = [r for r in rows if r["type"] == args.type]
+        if args.evolvable_only:
+            rows = [r for r in rows if r["evolvable"]]
+        for r in rows:
+            tag = "E" if r["evolvable"] else "F"
+            print(f"[{tag}] {r['type']:12} v{r['version']:<3} {r['path']}")
+        return
+
+    out_dir = os.path.dirname(os.path.abspath(args.output))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    tmp = args.output + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(registry, f, indent=2)
+    os.replace(tmp, args.output)
+    print(format_summary(registry))
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/synthesize_strategy.py
+++ b/tools/synthesize_strategy.py
@@ -38,6 +38,67 @@ def load_json_safe(path):
         return None
 
 
+# Keywords that signal a failure is likely caused by missing capability
+# rather than prompt/instruction wording. When these appear in failure
+# clusters we emit a tool-gap lens so the proposer considers creating
+# a new tool instead of rewriting prompts.
+TOOL_GAP_SIGNALS = (
+    "tool", "function", "api", "calculator", "search", "retriev",
+    "fetch", "parser", "extract", "regex", "browser", "shell",
+    "subprocess", "python_repl", "code_interpreter", "memory",
+)
+
+
+def _gap_analysis(config):
+    """Classify evolution regime based on best_score vs target_score.
+
+    Returns one of: "weak" (far from target), "mid", "ceiling" (near target),
+    plus the numeric values for logging. Implements the empirical finding
+    from Autogenesis Table 1 that weak models gain most from prompt/solution
+    evolution while near-ceiling models only gain from tool evolution.
+    """
+    best = config.get("best_score")
+    target = config.get("target_score")
+    if best is None:
+        return {"regime": "unknown", "best": None, "target": target, "gap": None}
+    # Fallback target when not configured — assume 0.9 is "good enough"
+    effective_target = target if target is not None else 0.9
+    gap = max(0.0, effective_target - best)
+    if gap >= 0.20:
+        regime = "weak"
+    elif gap <= 0.05:
+        regime = "ceiling"
+    else:
+        regime = "mid"
+    return {
+        "regime": regime,
+        "best": best,
+        "target": target,
+        "effective_target": effective_target,
+        "gap": gap,
+    }
+
+
+def _cluster_text(cluster):
+    parts = [str(cluster.get("description", "")), str(cluster.get("type", ""))]
+    return " ".join(parts).lower()
+
+
+def _tool_gap_signal(strategy):
+    """True if any failure cluster or failing example points at missing capability."""
+    for c in strategy.get("failure_clusters", []):
+        text = _cluster_text(c)
+        if any(s in text for s in TOOL_GAP_SIGNALS):
+            return True
+    for ex in strategy.get("failing_examples", []):
+        err = (ex.get("error") or "").lower()
+        if "no tool" in err or "has no attribute" in err or "tool not found" in err:
+            return True
+        if "ModuleNotFoundError" in (ex.get("error") or ""):
+            return True
+    return False
+
+
 def identify_target_files(config):
     """Identify which files proposers should focus on."""
     entry_point = config.get("entry_point", "")
@@ -56,6 +117,7 @@ def synthesize(config, insights, results, memory, production=None):
         "failure_clusters": [],
         "recommended_approaches": [],
         "avoid": [],
+        "regime": _gap_analysis(config),
     }
 
     strategy["primary_targets"] = identify_target_files(config)
@@ -130,6 +192,47 @@ def generate_lenses(strategy, config, insights, results, memory, production, max
     """Generate investigation lenses from available data sources."""
     lenses = []
     lens_id = 0
+
+    # Regime-aware priority lens (weak-model vs near-ceiling)
+    # This must come first so it survives the severity sort + truncation.
+    gap = _gap_analysis(config)
+    if gap["regime"] == "weak":
+        lens_id += 1
+        lenses.append({
+            "id": lens_id,
+            "question": (
+                f"Baseline score {gap['best']:.3f} is far from target "
+                f"{gap['effective_target']:.2f} (gap {gap['gap']:.2f}). "
+                "Focus on prompt clarity and instruction quality — rewrite the "
+                "system prompt and planner instructions to reduce ambiguity. "
+                "Empirically, weak-baseline agents gain most from prompt edits."
+            ),
+            "source": "regime_weak",
+            "severity": "high",
+            "context": gap,
+        })
+    elif gap["regime"] == "ceiling" or _tool_gap_signal(strategy):
+        reason = (
+            f"Baseline score {gap['best']:.3f} is near target "
+            f"{gap['effective_target']:.2f} — prompt edits have diminishing returns. "
+            "Inspect failing examples for missing capabilities."
+        ) if gap["regime"] == "ceiling" else (
+            "Failing examples reference missing tools or capabilities."
+        )
+        lens_id += 1
+        lenses.append({
+            "id": lens_id,
+            "question": (
+                f"{reason} Consider CREATING A NEW TOOL or helper function that the "
+                "agent can call. Identify one concrete capability the agent lacks, "
+                "write the tool as a new Python function with a clear docstring, "
+                "register it with the agent, and reference it from the system prompt. "
+                "Do not just rewrite existing prompts."
+            ),
+            "source": "tool_gap",
+            "severity": "critical" if gap["regime"] == "ceiling" else "high",
+            "context": {"gap": gap, "has_tool_signal": _tool_gap_signal(strategy)},
+        })
 
     # Failure cluster lenses (one per distinct cluster, max 3)
     for cluster in strategy.get("failure_clusters", [])[:3]:
@@ -285,6 +388,20 @@ def format_strategy_md(strategy, config):
         f"*Framework: {config.get('framework', 'unknown')} | Entry point: {config.get('entry_point', 'N/A')}*",
         "",
     ]
+
+    regime = strategy.get("regime") or {}
+    if regime.get("regime") not in (None, "unknown"):
+        best = regime.get("best")
+        target = regime.get("effective_target")
+        gap = regime.get("gap") or 0
+        lines.append(f"## Regime: **{regime['regime']}**  (best {best:.3f} vs target {target:.2f}, gap {gap:.3f})")
+        if regime["regime"] == "weak":
+            lines.append("- High headroom → prioritize prompt/instruction rewrites.")
+        elif regime["regime"] == "ceiling":
+            lines.append("- Near target → prioritize creating new tools/capabilities. Prompt edits have diminishing returns.")
+        else:
+            lines.append("- Mid-range → balanced prompt edits + targeted fixes.")
+        lines.append("")
 
     lines.append("## Target Files")
     for f in strategy.get("primary_targets", []):


### PR DESCRIPTION
## Summary

Implements four concrete gaps identified against the **Autogenesis** self-evolving agent protocol paper (arXiv 2604.15034) while staying stdlib-only and backwards-compatible with the existing pipeline.

- **`tools/resource_registry.py`** — classifies every project file into one of the five RSPL entity types (prompt / tool / agent / environment / memory), with content hash, auto-bumping version, deletion tombstones, and a binary learnability mask that auto-freezes `.env` / credentials. Maps to AGP Layer 1.
- **`tools/extract_contracts.py`** — AST-walks the agent source tree and emits a consolidated `contracts.md` (signatures, `@tool` decorators, docstrings, examples). Implements AGP Contract Generation — eliminates prompt/code drift and reduces prompt bloat.
- **`tools/archive_search.py`** — TF-IDF retrieval over `evolution_archive/*/{proposal.md, diff.patch, meta.json}`. Proposers can query past winners/losers by lens or failure description with `--winners-only` / `--losers-only`.
- **`tools/synthesize_strategy.py`** — regime-aware lens biasing. Computes `gap = target_score - best_score` and emits a prompt-focused lens when the baseline is weak (`gap ≥ 0.20`) or a **tool-gap** lens when near ceiling (`gap ≤ 0.05`) or when failure clusters reference missing tools. Mirrors the paper's empirical finding that weak baselines gain from prompt edits while near-ceiling baselines only gain from creating new tools (Table 1, GAIA +33.3% Level 3 from tool evolution).
- **`CLAUDE.md`** — labels pipeline phases with ρ/σ/ι/ε/κ (Reflect/Select/Improve/Evaluate/Commit), documents the RSPL-lite model, adds usage examples for the three new tools.

## Motivation

The Autogenesis paper (*Zhang, 2026*) formalizes self-evolving agents as a 2-layer protocol: RSPL (typed resources with versioning) + SEPL (5 operators over a shared state). Our current loop already maps to SEPL operators informally, but three capabilities were missing:

1. **Typed resources** → without them, proposers can only edit "the agent" as an opaque blob instead of targeting a prompt vs a tool.
2. **Contract generation** → prompts drift from code over time; paper's `skills.md` pattern fixes this.
3. **Tool evolution path** → the paper's single biggest empirical win (+33.3% on GAIA Level 3) comes from generating *new* tools, not rewording prompts. Our pipeline never emitted a lens that tells the proposer to create a new capability.

## Test plan

- [x] Syntax check all 28 Python tools (`python3 -c "import ast; ast.parse(...)"`)
- [x] `extract_contracts.py` — fixture with `@tool`-decorated functions detects both tools + classes + captures examples
- [x] `resource_registry.py` — all 5 RSPL types classified on a mixed fixture; `.env` auto-frozen; version bumps on content change; tombstones emitted for deletions
- [x] `archive_search.py` — 3-candidate synthetic archive: winner ranked first, loser on same topic second, unrelated filtered out; `--winners-only` / `--losers-only` filters work
- [x] `synthesize_strategy.py` — all three regimes (weak / ceiling / mid) emit the expected lens; tool-gap signal triggers correctly; missing `best_score` is handled (no regression)
- [x] Versions `package.json` ↔ `plugin.json` still synced (6.4.2)
- [x] Hooks remain valid

## Out of scope (follow-ups)

- Inference-time solution refinement (evolve-solution) — needs deeper integration with arbitrary user entry points.
- Per-resource rollback — the registry has hash+version; the apply-side (revert a single resource via archive diff) is a natural next PR.
- Formal TextGrad / GRPO optimizer plugins — operator labels are now in place, but the proposer contract would need a refactor to swap optimizers cleanly.